### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - 'main'
-      
+
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mariusdamm/fnvw/security/code-scanning/3](https://github.com/mariusdamm/fnvw/security/code-scanning/3)

To address the issue, add a `permissions` block to the workflow to explicitly limit the GITHUB_TOKEN's privileges. Since the workflow involves reading repository contents, extracting a version from a file, and pushing Docker images, the following permissions are required:

- `contents: read` is needed to read the repository contents.
- `packages: write` is required to push Docker images to GHCR.

The `permissions` block can be added globally at the root of the workflow file to apply to all jobs, as there is only one job (`build`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
