### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test Backend
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/mariusdamm/fnvw/security/code-scanning/2](https://github.com/mariusdamm/fnvw/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This ensures that all jobs in the workflow default to the least privilege necessary, unless overridden at the job level. Based on the workflow's current operations, the `contents: read` permission is sufficient to enable basic read operations, and no write permissions seem to be needed for any other actions. Update the `.github/workflows/test.yml` with the following minimal permissions:

```yaml
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
